### PR TITLE
#257 [BUG] :SessionSave doesn't actually accept an argument

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -899,7 +899,7 @@ function SetupAutocmds()
   vim.api.nvim_create_user_command(
     "SessionSave",
     SaveSession,
-    { bang = true, desc = "Save the current session. Based in cwd if no arguments are passed" }
+    { bang = true, nargs = '?', desc = "Save the current session. Based in cwd if no arguments are passed" }
   )
 
   vim.api.nvim_create_user_command("SessionRestore", SessionRestore, { bang = true, desc = "Restore Session" })


### PR DESCRIPTION
I have no experience developing in LUA or VIM/NeoVim plugins.
Please check possible side-effects that I might overlook.

This is so simple that I expect it to be wrong :-)